### PR TITLE
update capistrano-bundle-audit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,15 +14,14 @@ GEM
       blue-daemons (~> 1.1.11)
       i18n (~> 0.5)
       state_machine (~> 1.1)
-    bundler-audit (0.3.1)
+    bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    capistrano (3.3.3)
-      capistrano-stats (~> 1.0.3)
+    capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
-    capistrano-bundle_audit (0.0.3)
+    capistrano-bundle_audit (0.0.5)
       bundler-audit
       capistrano (~> 3.0)
     capistrano-bundler (1.1.3)
@@ -35,10 +34,9 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capistrano-stats (1.0.3)
     chronic (0.10.2)
     coderay (1.1.0)
-    colorize (0.7.3)
+    colorize (0.7.7)
     confstruct (0.2.7)
     diff-lcs (1.2.5)
     dor-workflow-service (1.7.2)
@@ -77,7 +75,7 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
+    net-ssh (2.9.2)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
     nokogiri-happymapper (0.5.9)
@@ -131,8 +129,8 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     slop (3.6.0)
-    sshkit (1.5.1)
-      colorize
+    sshkit (1.7.1)
+      colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     state_machine (1.2.0)
@@ -174,6 +172,3 @@ DEPENDENCIES
   simplecov (~> 0.7.1)
   sys-filesystem
   yard
-
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
update capistrano-bundle-audit to take advantage of bundle_audit_ignore and skip_bundle_audit
