### PR TITLE
Bypass bash script calling bundle - just call it directly

### DIFF
--- a/bin/weekly-status.sh
+++ b/bin/weekly-status.sh
@@ -2,6 +2,6 @@
 export BIN=`dirname $0`
 cd $BIN
 status='/tmp/sdr-weekly-status-report.txt'
-./bundle-exec.sh status_workflow.rb sdrIngestWF summary > $status
-./bundle-exec.sh status_storage.rb | grep -v 'Production Status' >> $status
+bundle exec status_workflow.rb sdrIngestWF summary > $status
+bundle exec status_storage.rb | grep -v 'Production Status' >> $status
 cat $status | mail -s 'SDR Weekly Production Report' sdr-discuss@lists.stanford.edu


### PR DESCRIPTION
  Fixes sul-dlss/operations-tasks#334