### PR TITLE
Bundle updates to resolve bundle-audit vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
-    archive-utils (0.0.1)
-      json_pure (~> 1.8)
+    activesupport (4.2.8)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    archive-utils (0.1.0)
       systemu (~> 2.6)
     awesome_print (1.2.0)
     blue-daemons (1.1.11)
@@ -39,7 +40,8 @@ GEM
     chronic (0.10.2)
     coderay (1.1.0)
     colorize (0.7.3)
-    confstruct (0.2.7)
+    confstruct (1.0.2)
+      hashie (~> 3.3)
     coveralls (0.7.0)
       multi_json (~> 1.3)
       rest-client
@@ -47,22 +49,28 @@ GEM
       term-ansicolor
       thor
     diff-lcs (1.2.5)
-    dor-workflow-service (1.7.2)
-      activesupport (~> 3.2)
-      confstruct (~> 0.2.7)
+    domain_name (0.5.20170223)
+      unf (>= 0.0.5, < 1.0.0)
+    dor-workflow-service (1.7.7)
+      activesupport (>= 3.2.1, < 5)
+      confstruct (>= 0.2.7, < 2)
       nokogiri (~> 1.6.0)
-      rest-client (~> 1.6.7)
+      rest-client (~> 1.7)
+      retries
     druid-tools (0.3.1)
     equivalent-xml (0.5.1)
       nokogiri (>= 1.4.3)
     fakeweb (1.3.0)
-    faraday (0.9.0)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.6)
-    i18n (0.7.0)
-    json (1.8.1)
-    json_pure (1.8.1)
-    lyber-core (3.2.5)
+    hashie (3.5.5)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (0.8.1)
+    json (2.0.3)
+    json_pure (1.8.6)
+    lyber-core (3.3.0)
       dor-workflow-service (~> 1.7)
     lyberteam-capistrano-devel (3.1.0)
       capistrano (~> 3.0)
@@ -70,22 +78,24 @@ GEM
       capistrano-one_time_key
       capistrano-releaseboard
     method_source (0.8.2)
-    mime-types (1.25.1)
-    mini_portile (0.6.1)
-    moab-versioning (1.4.2)
+    mime-types (2.99.3)
+    mini_portile2 (2.1.0)
+    minitest (5.10.1)
+    moab-versioning (1.4.4)
       confstruct
       json
       nokogiri
       nokogiri-happymapper
       systemu
     mono_logger (1.1.0)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
-    nokogiri (1.6.5)
-      mini_portile (~> 0.6.0)
+    netrc (0.11.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
     pry (0.10.1)
@@ -96,8 +106,6 @@ GEM
     rack-protection (1.5.3)
       rack
     rake (10.4.2)
-    rdoc (4.1.2)
-      json (~> 1.4)
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
@@ -107,9 +115,11 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    rest-client (1.6.8)
-      mime-types (~> 1.16)
-      rdoc (>= 2.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    retries (0.0.5)
     robot-controller (2.0.3)
       bluepill (= 0.0.68)
       rake (~> 10.3)
@@ -144,12 +154,18 @@ GEM
     state_machine (1.2.0)
     sys-filesystem (1.1.3)
       ffi
-    systemu (2.6.4)
+    systemu (2.6.5)
     term-ansicolor (1.4.0)
       tins (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.6)
     tilt (2.0.1)
     tins (1.13.0)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     vegas (0.1.11)
       rack (>= 1.0.0)
     whenever (0.9.4)
@@ -186,4 +202,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.14.6


### PR DESCRIPTION
_might_ fix #30 but there are some substantial library updates for DLSS infrastructure in this, so this could break some unit tests.  Even if it passes unit tests, let's not merge this until some accessioning tests can be run on it on the sdr-services-test system(s).

```
bundle update nokogiri
bundle update sdr-replication
bundle update rest-client
bundle update faraday
bundle update dor-workflow-service
bundle update lyber-core
```