### PR TITLE
Manual merge master into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 * Richard Anderson
 * Darren Weber
 
-## Project Directory Structure
+See the [Wiki](https://github.com/sul-dlss/robot-master/wiki) for general documentation on the robots infrastructure.
+
+== Project Directory Structure
     |
     ---config
     |  |

--- a/bin/weekly-status.sh
+++ b/bin/weekly-status.sh
@@ -2,6 +2,6 @@
 export BIN=`dirname $0`
 cd $BIN
 status='/tmp/sdr-weekly-status-report.txt'
-./bundle-exec.sh status_workflow.rb sdrIngestWF summary > $status
-./bundle-exec.sh status_storage.rb | grep -v 'Production Status' >> $status
+bundle exec status_workflow.rb sdrIngestWF summary > $status
+bundle exec status_storage.rb | grep -v 'Production Status' >> $status
 cat $status | mail -s 'SDR Weekly Production Report' sdr-discuss@lists.stanford.edu


### PR DESCRIPTION
After careful review of the diffs between `master` and `develop`, this PR will pull in a couple recent changes to master into develop.  This will pave the way for merging develop into master and then removing the develop branch.

The recent changes to master that are not in develop can be seen in https://github.com/sul-dlss/sdr-preservation-core/pull/35, but a lot of those changes are already in develop; so this PR just picks up the pieces that make a real difference.  These changes are relatively minor and may not impact the specs at all, as they are basically code-no-op changes.