### PR TITLE
Resolve some master..develop conflicts in lib/boot.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,21 +9,21 @@ gem 'sys-filesystem'
 gem 'pry'
 
 # DLSS gems
-gem 'dor-workflow-service', '~> 1.7'
+gem 'dor-workflow-service', '~> 1.8'
 gem 'druid-tools'
-gem 'lyber-core',  '~> 3.2', '>= 3.2.2'
+gem 'lyber-core', '~> 3.3'
 gem 'moab-versioning', '~> 1.3' #, :path => '/Users/rnanders/Code/Github/moab-versioning' #
 gem 'robot-controller', '~> 2.0'
 gem 'sdr-replication', '~> 0.5' #,:path => '/Users/rnanders/Code/Github/sdr-replication' #
 
 group :development do
-	gem 'awesome_print'
-	gem 'equivalent-xml'
-	gem 'fakeweb'
-	gem 'rspec', '~> 2.14'
-	gem 'simplecov'
-	gem 'coveralls'
-	gem 'yard'
+  gem 'awesome_print'
+  gem 'equivalent-xml'
+  gem 'fakeweb'
+  gem 'rspec', '~> 2.14'
+  gem 'simplecov'
+  gem 'coveralls'
+  gem 'yard'
 end
 
 # Do not place the capistrano-related gems in the default or development bundle group

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (4.2.8)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     archive-utils (0.0.1)
       json_pure (~> 1.8)
       systemu (~> 2.6)
@@ -38,7 +40,8 @@ GEM
     chronic (0.10.2)
     coderay (1.1.0)
     colorize (0.7.3)
-    confstruct (0.2.7)
+    confstruct (1.0.2)
+      hashie (~> 3.3)
     coveralls (0.7.0)
       multi_json (~> 1.3)
       rest-client
@@ -51,24 +54,35 @@ GEM
       capistrano-bundle_audit (>= 0.1.0)
       capistrano-one_time_key
       capistrano-shared_configs
-    dor-workflow-service (1.7.2)
-      activesupport (~> 3.2)
-      confstruct (~> 0.2.7)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    dor-workflow-service (1.8.0)
+      activesupport (>= 3.2.1, < 5)
+      confstruct (>= 0.2.7, < 2)
+      faraday (~> 0.9.2)
+      net-http-persistent (~> 2.9.4)
       nokogiri (~> 1.6.0)
-      rest-client (~> 1.6.7)
+      rest-client (~> 1.7)
+      retries
     druid-tools (0.3.1)
     equivalent-xml (0.5.1)
       nokogiri (>= 1.4.3)
     fakeweb (1.3.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.6)
-    i18n (0.7.0)
-    json (1.8.1)
+    hashie (3.5.5)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (0.8.4)
+    json (2.1.0)
     json_pure (1.8.1)
-    lyber-core (3.2.5)
+    lyber-core (3.3.1)
       dor-workflow-service (~> 1.7)
     method_source (0.8.2)
-    mime-types (1.25.1)
-    mini_portile (0.6.1)
+    mime-types (2.99.3)
+    mini_portile2 (2.1.0)
+    minitest (5.10.2)
     moab-versioning (1.4.2)
       confstruct
       json
@@ -76,12 +90,15 @@ GEM
       nokogiri-happymapper
       systemu
     mono_logger (1.1.0)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
-    nokogiri (1.6.5)
-      mini_portile (~> 0.6.0)
+    netrc (0.11.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
     pry (0.10.1)
@@ -92,8 +109,6 @@ GEM
     rack-protection (1.5.3)
       rack
     rake (10.4.2)
-    rdoc (4.1.2)
-      json (~> 1.4)
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
@@ -103,9 +118,11 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    rest-client (1.6.8)
-      mime-types (~> 1.16)
-      rdoc (>= 2.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    retries (0.0.5)
     robot-controller (2.0.3)
       bluepill (= 0.0.68)
       rake (~> 10.3)
@@ -144,8 +161,14 @@ GEM
     term-ansicolor (1.4.0)
       tins (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.6)
     tilt (2.0.1)
     tins (1.13.0)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
     vegas (0.1.11)
       rack (>= 1.0.0)
     whenever (0.9.4)
@@ -163,12 +186,12 @@ DEPENDENCIES
   confstruct
   coveralls
   dlss-capistrano
-  dor-workflow-service (~> 1.7)
+  dor-workflow-service (~> 1.8)
   druid-tools
   equivalent-xml
   fakeweb
   json_pure
-  lyber-core (~> 3.2, >= 3.2.2)
+  lyber-core (~> 3.3)
   moab-versioning (~> 1.3)
   nokogiri
   pry
@@ -182,4 +205,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/lib/boot.rb
+++ b/lib/boot.rb
@@ -7,6 +7,21 @@ require_relative 'libdir'
 ROBOT_ROOT = Pathname(__dir__).parent.to_s
 HOME = ENV['HOME']
 
+# Sdr::Config contains the constants that are required within this project
+module Sdr
+  Config = Confstruct::Configuration.new do
+    ingest_transfer do
+      account "userid@dor-host.stanford.edu"
+      export_dir "/dor/export/"
+    end
+    logdir File.join(ROBOT_ROOT, 'log')
+    migration_source "/services-disk/sdr2objects"
+    sdr_recovery_home nil
+    enqueue_max 10
+    audit_verbose false
+  end
+end
+
 # The Dor::Config object is created in dor-services-gem/lib/dor/config.rb
 # and initialized with the data in dor-services-gem/config/config_defaults.yml
 module Dor
@@ -37,54 +52,25 @@ end
 #   end
 # end
 
-# Sdr::Config contains the constants that are required within this project
-module Sdr
-  Config = Confstruct::Configuration.new do
-    ingest_transfer do
-      account "userid@dor-host.stanford.edu"
-      export_dir "/dor/export/"
-    end
-    logdir File.join(ROBOT_ROOT, 'log')
-    migration_source "/services-disk/sdr2objects"
-    sdr_recovery_home nil
-    enqueue_max 10
-    audit_verbose false
-  end
-end
-
-
 require 'druid-tools'
-require 'dor/services/workflow_service'
 require 'lyber_core/robot'
 require 'lyber_core/log'
 require 'moab_stanford'
 include Stanford
 require 'sdr_replication'
 
-# Load the environment file based on Environment.  Default to local
+# Load the environment file.  The environment config file should
+# override the default configurations above.
 environment = ENV['ROBOT_ENVIRONMENT'] || 'development'
 require File.join(ROBOT_ROOT,"config/environments/#{environment}")
 
+require 'dor/services/workflow_service'
+log_file = File.join(ROBOT_ROOT, 'log', 'workflow_service.log')
+wfs_logger = Logger.new(log_file, 'weekly')
+wfs_options = {
+  logger: wfs_logger
+}
+Dor::WorkflowService.configure Dor::Config.workflow.url, wfs_options
+
 require 'sdr/sdr_robot'
 
-module Dor
-  module WorkflowService
-    class << self
-      # @param [String] url points to the workflow service
-      # @param [Hash] opts optional params
-      # @option opts [String] :client_cert_file path to an SSL client certificate
-      # @option opts [String] :client_key_file path to an SSL key file
-      # @option opts [String] :client_key_pass password for the key file
-      def configure(url, opts={})
-        params = {}
-        params[:ssl_client_cert] = OpenSSL::X509::Certificate.new(File.read(opts[:client_cert_file])) if opts[:client_cert_file]
-        params[:ssl_client_key]  = OpenSSL::PKey::RSA.new(File.read(opts[:client_key_file]), opts[:client_key_pass]) if opts[:client_key_file]
-        params[:timeout] = 120
-        params[:open_timeout] = 120
-        @@resource = RestClient::Resource.new(url, params)
-      end
-    end
-  end
-end
-
-Dor::WorkflowService.configure Dor::Config.workflow.url


### PR DESCRIPTION
Trying to resolve a conflict in `lib/boot.rb` for https://github.com/sul-dlss/sdr-preservation-core/pull/34.  When this PR is merged into master, it could resolve the conflict in merging develop into master.

The master branch and this PR branch are using `gem 'dor-workflow-service', '~> 1.7'` and the config changes to the workflow init in this PR were taken from the develop branch, which is now using `'dor-workflow-service', '~> 2.0'` (when that update in develop was made in https://github.com/sul-dlss/sdr-preservation-core/commit/d663b47af20e079dd181f6d59e9ad53a8db9a80f, there were no config changes made to the `lib/boot.rb` file, so the config changes predate the WFS 2.x update).  There were workflow-service config changes in develop made in:
- https://github.com/sul-dlss/sdr-preservation-core/commit/547962dc26c5ae579b402eea1de8b7c17c09197e
  - updated to dor-workflow-service (1.8.0 from 1.7.0)
  - updated to lyber-core (3.3.x from 3.2.x)
- https://github.com/sul-dlss/sdr-preservation-core/commit/fe79bdad9ad20a1794b96bbe47a460d05fe0825b
  - kinda no-op change, just moving the order of config inits

- [x] If the config changes made in `develop` are associated with an update to a couple of DLSS gems, try adding them into this PR and see if it works out OK.
  - update to dor-workflow-service 1.8.0
  - update to  lyber-core 3.3.1 (bumped into a bug in lyber-core 3.3.0)

- Note that `dor-workflow-service 1.8.0` still restricts nokogiri to 1.6.x, so this PR does not resolve some bundle audit problems.  There is a PR to patch `dor-workflow-service 1.8.1` in https://github.com/sul-dlss/dor-workflow-service/pull/41 so that this PR could also do an update on nokogiri.  I don't think we need to wait for that here, however.

The goal of this PR is to get the master `lib/boot.rb` close to the `develop` version, which it does a good job of and should be enough that git can do the rest automatically, i.e. the diff is reduced substantially.
```bash
$ git diff closer-to-develop-lib-boot..develop lib/boot.rb
diff --git a/lib/boot.rb b/lib/boot.rb
index 1688c7e..680e9ea 100644
--- a/lib/boot.rb
+++ b/lib/boot.rb
@@ -52,11 +52,11 @@ end
 #   end
 # end
 
+
 require 'druid-tools'
 require 'lyber_core/robot'
 require 'lyber_core/log'
-require 'moab_stanford'
-include Stanford
+require 'moab/stanford'
 require 'sdr_replication'
 
 # Load the environment file.  The environment config file should
```