### PR TITLE
Use explicit namespaces for moab-versioning classes

### DIFF
--- a/bin/object_content_inventory.rb
+++ b/bin/object_content_inventory.rb
@@ -39,7 +39,7 @@ druidlist.each_line {|line|
 
 druids.each do |druid|
   druid = "druid:#{druid}" unless druid.start_with?('druid')
-  content_group = StorageServices.retrieve_file_group('content',druid)
+  content_group = Moab::StorageServices.retrieve_file_group('content',druid)
   content_group.path_hash.each do |file,signature|
     puts "#{druid}, #{file.to_s}, #{signature.md5}, #{signature.size}"
   end

--- a/bin/purge_object.rb
+++ b/bin/purge_object.rb
@@ -53,7 +53,7 @@ class PurgeObject
   # @return [Moab::StorageObject] The storage object representing the digital object's storage
   def find_storage_object(druid)
     druid = "druid:#{druid}" unless druid.start_with?('druid')
-    StorageServices.find_storage_object(druid)
+    Moab::StorageServices.find_storage_object(druid)
   end
 
   # Find the digital object version's storage sub-location (not used at present)

--- a/bin/status_activity.rb
+++ b/bin/status_activity.rb
@@ -205,7 +205,7 @@ class StatusActivity < Status
         druid = args.shift.to_s.downcase
         if druid != ''
           druid = "druid:#{druid}" unless druid.start_with?('druid')
-          @storage_object = StorageServices.find_storage_object(druid, include_deposit=true)
+          @storage_object = Moab::StorageServices.find_storage_object(druid, include_deposit=true)
           @storage_version = @storage_object.current_version
           @filegroup = @storage_version.file_category_pathname('metadata')
           @storage_deposit = @storage_object.deposit_bag_pathname

--- a/lib/sdr_audit/audit_verify.rb
+++ b/lib/sdr_audit/audit_verify.rb
@@ -29,7 +29,7 @@ module Robots
         # @return [Boolean] Reconcile manifests against the files in the digital object's storage location
         def audit_verify(druid)
           LyberCore::Log.debug("( #{__FILE__} : #{__LINE__} ) Enter audit_verify")
-          storage_object = StorageServices.storage_object(druid, create=false)
+          storage_object = Moab::StorageServices.storage_object(druid, create=false)
           result = storage_object.verify_object_storage
           if result.verified
             LyberCore::Log.info "Verification Result:\n" + result.to_json(verbose=Sdr::Config.audit_verbose)

--- a/lib/sdr_ingest/complete_deposit.rb
+++ b/lib/sdr_ingest/complete_deposit.rb
@@ -22,7 +22,7 @@ module Robots
         #   See LyberCore::Robot#work
         def perform(druid)
           LyberCore::Log.debug("( #{__FILE__} : #{__LINE__} ) Enter perform")
-          storage_object = StorageServices.find_storage_object(druid, include_deposit=true)
+          storage_object = Moab::StorageServices.find_storage_object(druid, include_deposit=true)
           storage_object.object_pathname.mkpath
           complete_deposit(druid, storage_object)
         end
@@ -51,7 +51,7 @@ module Robots
 
         def verification_files(druid)
           files = []
-          files << StorageServices.object_path(druid).to_s
+          files << Moab::StorageServices.object_path(druid).to_s
           files
         end
 

--- a/lib/sdr_ingest/ingest_cleanup.rb
+++ b/lib/sdr_ingest/ingest_cleanup.rb
@@ -64,7 +64,7 @@ module Robots
 
         def verification_files(druid)
           files = []
-          files << StorageServices.object_path(druid).to_s
+          files << Moab::StorageServices.object_path(druid).to_s
           files
         end
 

--- a/lib/sdr_ingest/verify_agreement.rb
+++ b/lib/sdr_ingest/verify_agreement.rb
@@ -115,7 +115,7 @@ module Robots
           if @@valid_apo_ids.include?(apo_druid)
             true
           else
-            apo_object = StorageServices.find_storage_object(apo_druid)
+            apo_object = Moab::StorageServices.find_storage_object(apo_druid)
             if apo_object.object_pathname.directory?
               @@valid_apo_ids << apo_druid
               true

--- a/lib/sdr_migration/migration_complete.rb
+++ b/lib/sdr_migration/migration_complete.rb
@@ -62,7 +62,7 @@ module Robots
 
         def verification_files(druid)
           files = []
-          files << StorageServices.object_path(druid).to_s
+          files << Moab::StorageServices.object_path(druid).to_s
           files
         end
 

--- a/lib/sdr_migration/migration_transfer.rb
+++ b/lib/sdr_migration/migration_transfer.rb
@@ -104,7 +104,7 @@ module Robots
 
         def get_version_inventory(druid, deposit_bag_pathname)
           # Create new version inventory for version 1.
-          version_inventory = FileInventory.new(:type => "version", :digital_object_id => druid, :version_id => 1)
+          version_inventory = Moab::FileInventory.new(:type => "version", :digital_object_id => druid, :version_id => 1)
           content_group = get_data_group(deposit_bag_pathname, 'content')
           version_inventory.groups << content_group
           upgrade_content_metadata(deposit_bag_pathname, content_group)
@@ -133,7 +133,7 @@ module Robots
         end
 
         def get_version_additions(druid, version_inventory)
-          signature_catalog = SignatureCatalog.new(:digital_object_id => druid)
+          signature_catalog = Moab::SignatureCatalog.new(:digital_object_id => druid)
           version_additions = signature_catalog.version_additions(version_inventory)
           version_additions
         end

--- a/lib/sdr_recovery/recovery_restore.rb
+++ b/lib/sdr_recovery/recovery_restore.rb
@@ -30,7 +30,7 @@ module Robots
         # @return [void] transfer recovered object files to repository storage.
         def recovery_restore(druid)
           LyberCore::Log.debug("( #{__FILE__} : #{__LINE__} ) Enter recovery_restore")
-          storage_object = StorageServices.storage_object(druid, create=true)
+          storage_object = Moab::StorageServices.storage_object(druid, create=true)
           recovery_path = Pathname(Sdr::Config.sdr_recovery_home).join(druid.sub('druid:', ''))
           storage_object.restore_object(recovery_path)
           result = storage_object.verify_object_storage
@@ -57,7 +57,7 @@ module Robots
 
         def verification_files(druid)
           files = []
-          files << StorageServices.object_path(druid).to_s
+          files << Moab::StorageServices.object_path(druid).to_s
           files
         end
 

--- a/spec/sdr_ingest/complete_deposit_spec.rb
+++ b/spec/sdr_ingest/complete_deposit_spec.rb
@@ -1,28 +1,26 @@
 require 'sdr_ingest/complete_deposit'
 require 'spec_helper'
-include Robots::SdrRepo::SdrIngest
 
-describe CompleteDeposit do
+describe Robots::SdrRepo::SdrIngest::CompleteDeposit do
 
   before(:all) do
     @druid = "druid:jc837rq9922"
   end
 
   before(:each) do
-    @cd = CompleteDeposit.new
+    @cd = described_class.new
   end
 
   specify "CompleteDeposit#initialize" do
-    expect(@cd).to be_an_instance_of(CompleteDeposit)
     expect(@cd).to be_a_kind_of(LyberCore::Robot)
     expect(@cd.class.workflow_name).to eq('sdrIngestWF')
     expect(@cd.class.step_name).to eq('complete-deposit')
   end
 
   specify "CompleteDeposit#perform" do
-    mock_so = double(StorageObject)
+    mock_so = double(Moab::StorageObject)
     mock_path = double(Pathname)
-    expect(StorageServices).to receive(:find_storage_object).with(@druid,true).and_return(mock_so)
+    expect(Moab::StorageServices).to receive(:find_storage_object).with(@druid,true).and_return(mock_so)
     expect(mock_so).to receive(:object_pathname).and_return(mock_path)
     expect(mock_path).to receive(:mkpath)
     expect(@cd).to receive(:complete_deposit).with(@druid,mock_so)
@@ -30,10 +28,10 @@ describe CompleteDeposit do
   end
 
   specify "CompleteDeposit#complete_deposit" do
-    storage_object = double(StorageObject)
-    new_version = double(StorageObjectVersion)
+    storage_object = double(Moab::StorageObject)
+    new_version = double(Moab::StorageObjectVersion)
     expect(storage_object).to receive(:ingest_bag).and_return(new_version)
-    result = double(VerificationResult)
+    result = double(Moab::VerificationResult)
     allow(result).to receive(:verified).and_return(true)
     expect(new_version).to receive(:verify_version_storage).and_return(result)
     @cd.complete_deposit(@druid,storage_object)

--- a/spec/sdr_migration/migration_complete_spec.rb
+++ b/spec/sdr_migration/migration_complete_spec.rb
@@ -22,9 +22,9 @@ describe MigrationComplete do
   end
 
   specify "MigrationComplete#perform" do
-    mock_so = double(StorageObject)
+    mock_so = double(Moab::StorageObject)
     mock_path = double(Pathname)
-    expect(StorageServices).to receive(:find_storage_object).with(@druid,true).and_return(mock_so)
+    expect(Moab::StorageServices).to receive(:find_storage_object).with(@druid,true).and_return(mock_so)
     expect(mock_so).to receive(:object_pathname).and_return(mock_path)
     expect(mock_path).to receive(:mkpath)
     expect(@rs).to receive(:complete_deposit).with(@druid,mock_so)

--- a/spec/sdr_recovery/recovery_restore_spec.rb
+++ b/spec/sdr_recovery/recovery_restore_spec.rb
@@ -29,9 +29,9 @@ describe RecoveryRestore do
   specify "RecoveryComplete#recovery_restore" do
     storage_object = double(Moab::StorageObject)
     recovery_path = Pathname(Sdr::Config.sdr_recovery_home).join(@druid.sub('druid:',''))
-    expect(StorageServices).to receive(:storage_object).with(@druid,true).and_return(storage_object)
+    expect(Moab::StorageServices).to receive(:storage_object).with(@druid,true).and_return(storage_object)
     expect(storage_object).to receive(:restore_object).with(recovery_path)
-    verification_result = double(VerificationResult)
+    verification_result = double(Moab::VerificationResult)
     allow(verification_result).to receive(:verified).and_return(true)
     expect(storage_object).to receive(:verify_object_storage).and_return(verification_result)
     @rr.recovery_restore(@druid)


### PR DESCRIPTION
`git cherry-pick` 938b0512185677ad535947b3164db0630e037393 (from `develop` branch).