### PR TITLE
Fix bin/menu.rb

### DIFF
--- a/bin/menu.rb
+++ b/bin/menu.rb
@@ -4,17 +4,15 @@ require_relative 'environment'
 require_relative 'status_activity'
 require_relative 'status_storage'
 require_relative 'status_workflow'
-require_relative 'status_monitor'
 
 class Menu
 
   def self.syntax()
     puts <<-EOF
 
-    Syntax: bundle-exec.sh menu.rb  {#{WorkflowNames.join('|')}}
+Syntax: bundle exec menu.rb  {#{WorkflowNames.join('|')}}
 
-    EOF
-
+EOF
   end
 
   def initialize(workflow)
@@ -107,7 +105,9 @@ class Menu
 end
 
 # This is the equivalent of a java main method
-if __FILE__ == $0
+FILE=`basename #{__FILE__}`
+SCRIPT=`basename #{$0}`
+if FILE == SCRIPT
   workflow = ARGV.shift.to_s
   if WorkflowNames.include?(workflow)
     menu = Menu.new(workflow)


### PR DESCRIPTION
Bug fixes to the `bin/menu.rb` utility.  This PR fixes it, but I can't comment on whether it's still used or useful for the DOR/SDR accessioning service staff.

Some example calls to this util:

```
$ bundle exec bin/menu.rb 

Syntax: bundle exec menu.rb  {sdrAuditWF|sdrIngestWF|sdrMigrationWF|sdrRecoveryWF}

$ bundle exec bin/menu.rb sdrIngestWF

Menu for sdrIngestWF:
---------------------
  menu                                = Display this menu
  storage                             = Report storage filesystem status
  workflow {detail|summary|waiting}   = Report workflow database status
  list     {comp..|err..}[n]          = Report current or recent robot activity 
  set      {druid|version|group} {id} = Set the object/version/filegroup focus and/or list the object versions
  view     {druid|version|group} {id} = Set the object/version/filegroup focus and list the child folders/files
  view     {log|pipeline|urls|dor}    = view object's logfile, recent pipeline history, URLs, or DOR files
  view     file/tree {name|path}      = view specified file or directory structure
  quit                                = Exit

sdrIngestWF (development) > quit
```