### PR TITLE
Remove the dotenv gem (it is not required anywhere)

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,4 +1,0 @@
-# https://github.com/bkeepers/dotenv
-export ROBOT_ENVIRONMENT=development
-export PRIVATE_CONFIG_PATH=/tmp/example/config
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'confstruct'
-gem 'dotenv'
 gem 'nokogiri'
 gem 'rake'
 gem 'rest-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,6 @@ GEM
       net-http-persistent (>= 2.9.4, < 4.a)
       nokogiri (~> 1.6)
       retries
-    dotenv (2.0.2)
     druid-tools (0.4.1)
     equivalent-xml (0.5.1)
       nokogiri (>= 1.4.3)
@@ -193,7 +192,6 @@ DEPENDENCIES
   coveralls
   dlss-capistrano (~> 3.0)
   dor-workflow-service (~> 2.0)
-  dotenv
   druid-tools
   equivalent-xml
   fakeweb


### PR DESCRIPTION
This moves closer to fixing some issues in #8 and it helps to resolve some conflicts between `develop` and `master` for #34 

The gem is not required anywhere, i.e.
```sh
$ git grep 'dotenv'  # nothing found
```