### PR TITLE
bundle update druid-tools # 0.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       net-http-persistent (>= 2.9.4, < 4.a)
       nokogiri (~> 1.6)
       retries
-    druid-tools (0.3.1)
+    druid-tools (0.4.1)
     equivalent-xml (0.5.1)
       nokogiri (>= 1.4.3)
     fakeweb (1.3.0)


### PR DESCRIPTION
This is the latest version of druid-tools, which brings `master` into line with `develop` (to resolve a conflict in #34).

The update from 0.3.x to 0.4.x seems to have only added functionality, see
- https://github.com/sul-dlss/druid-tools/compare/v0.3.3...v0.4.0
- https://github.com/sul-dlss/druid-tools/compare/v0.4.0...v0.4.1